### PR TITLE
Fixed bug with call to _.Array instead of _.isArray

### DIFF
--- a/lib/attribute-value-helpers.js
+++ b/lib/attribute-value-helpers.js
@@ -14,13 +14,13 @@ helpers.valueObject = function(val){
 
   if (_.isNumber(val)){
     return {N: val.toString()};
-  };
+  }
 
   if (_.isBoolean(val)){
     return {BOOL: val};
   }
 
-  if (_.Array(val)) {
+  if (_.isArray(val)) {
     return {L: val};
   }
 


### PR DESCRIPTION
@mmilleruva 

lib/attribute-value-helpers.js calls _.Array, which isn't a function. Changed to _.isArray.
